### PR TITLE
Update docking.py

### DIFF
--- a/malt/utils/docking.py
+++ b/malt/utils/docking.py
@@ -31,7 +31,7 @@ def vina_docking(smiles, protein):
 
         else:
             os.system(
-                "cp %s %s" % (protein, tempdirname),
+                "cp %s %s/protein.pdb" % (protein, tempdirname),
             )
 
         os.system(


### PR DESCRIPTION
Minor bug fix as the function won't run when passed an existing pdb file. Need to rename as `protein.pdb` to fit in with the rest of the pipeline.